### PR TITLE
add volumes for caddy

### DIFF
--- a/install.md
+++ b/install.md
@@ -156,6 +156,8 @@ services:
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./ssl:/gmonit/ssl
+      - caddy_data:/data
+      - caddy_config:/config
     ports:
       - 80:80
       - 443:443
@@ -169,9 +171,16 @@ services:
         condition: service_healthy
       collector:
         condition: service_healthy
+
+# docker volume create gmonit_caddy_data
+volumes:
+  caddy_data:
+    external: true
+    name: gmonit_caddy_data
+  caddy_config:
 ```
 
->Для всех заглушек вида `<<SOME_VALUE>>` нужно задать конкретные значения. 
+>Для всех заглушек вида `<<SOME_VALUE>>` нужно задать конкретные значения.
 
 >Все URL вида `*.example.ru` заменить на реальные адреса для Grafana и коллектора
 
@@ -180,6 +189,10 @@ services:
 - ./schema - схема данных для Clickhouse
 - ./ssl - сертификаты для выделенных доменов
 - Caddyfile - файл с настройками для Caddy
+
+Нужно создать внешние вольюмы:
+
+- `docker volume create gmonit_caddy_data`
 
 6. Запросить у команды GMonit актуальный `лицензионный колюч`.
 

--- a/install.md
+++ b/install.md
@@ -157,7 +157,6 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./ssl:/gmonit/ssl
       - caddy_data:/data
-      - caddy_config:/config
     ports:
       - 80:80
       - 443:443
@@ -177,7 +176,6 @@ volumes:
   caddy_data:
     external: true
     name: gmonit_caddy_data
-  caddy_config:
 ```
 
 >Для всех заглушек вида `<<SOME_VALUE>>` нужно задать конкретные значения.


### PR DESCRIPTION
Я словил ошибку, что за последнюю неделю сгенерировал 5 сертификатов.
И Let's encrypt отказывается новый выпускать.

Видимо в образе caddy не создается анонимный вольюм. Т.к. тот же постргрес или кликхаус не теряют данные, хотя вольюмы я не прописывал.

По caddy в доке советуют внешний вольюм подключать.
 
https://hub.docker.com/_/caddy
