### PR TITLE
bump postgres 13.1 -> 18.3 with explicit PGDATA

### DIFF
--- a/examples/pilot-letsencrypt/compose.yaml
+++ b/examples/pilot-letsencrypt/compose.yaml
@@ -25,9 +25,10 @@ services:
 
   postgres:
     restart: unless-stopped
-    image: postgres:13.1
+    image: postgres:18.3
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
       test: pg_isready -U postgres
       interval: 10s

--- a/examples/pilot/compose.yaml
+++ b/examples/pilot/compose.yaml
@@ -25,9 +25,10 @@ services:
 
   postgres:
     restart: unless-stopped
-    image: postgres:13.1
+    image: postgres:18.3
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
       test: pg_isready -U postgres
       interval: 10s


### PR DESCRIPTION
## Problem

`postgres:18+` changed default `PGDATA` to `/var/lib/postgresql/18/docker`. 
With existing mount `./postgres/data:/var/lib/postgresql/data`, the container 
fails on first start with `unused mount/volume` — even on an empty directory.

## Fix

- Bump image `postgres:13.1` → `postgres:18.3` (minor pinned per convention)
- Set `PGDATA=/var/lib/postgresql/data/pgdata` to keep existing mount and place 
  pg18 data in a subdirectory (workaround suggested by the postgres image itself)

## Validation

Reproduced and verified end-to-end on sandbox (postgres:18.3 / Debian 13) and 
on MOEX pilot deployment (2026-05-18). All 7 services healthy, 
`./postgres/data/pgdata/` initialised correctly.

Refs: docker-library/postgres#1259, docker-library/postgres#37
